### PR TITLE
Fixed issue with Log.log_data

### DIFF
--- a/log_storage/models.py
+++ b/log_storage/models.py
@@ -28,8 +28,11 @@ class Log(models.Model):
     @property
     def log_data(self):
         if self.save_file:
-            with open(self.get_filename(), 'rb') as f:
-                return f.read().decode('utf-8')
+            if self.filename:
+                with open(self.get_filename(), 'rb') as f:
+                    return f.read().decode('utf-8')
+            else:
+                return u''
         else:
             return self.db_log_data or u''
 

--- a/log_storage/tests.py
+++ b/log_storage/tests.py
@@ -1,3 +1,6 @@
+import logging
+
+
 import django.test as unittest
 
 from log_storage.models import Log
@@ -5,7 +8,6 @@ from log_storage.models import Log
 
 class TestLogRecordingToFile(unittest.TestCase):
     def setUp(self):
-        import logging
         self.log = Log(save_file=True)
         self.logger = logging.getLogger('test.'+__name__)
         self.logger.setLevel(logging.DEBUG)
@@ -27,12 +29,13 @@ class TestLogRecordingToFile(unittest.TestCase):
         self.assertIn(u"debug", self.log.log_data)
         self.assertIn(u"test.log_storage.tests", self.log.log_data)
 
-
+    def test_log_data(self):
+        """Test that calling log.log_data before logging anything won't throw error."""
+        self.assertEqual('', self.log.log_data)
 
 
 class TestLogRecordingToDb(unittest.TestCase):
     def setUp(self):
-        import logging
         self.log = Log(save_file=False)
         self.logger = logging.getLogger('test.'+__name__)
         self.logger.setLevel(logging.DEBUG)
@@ -54,5 +57,6 @@ class TestLogRecordingToDb(unittest.TestCase):
         self.assertIn(u"debug", self.log.log_data)
         self.assertIn(u"test.log_storage.tests", self.log.log_data)
 
-
-
+    def test_log_data(self):
+        """Test that calling log.log_data before logging anything won't throw error."""
+        self.assertEqual('', self.log.log_data)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='log_storage',
-    version='0.4.0',
+    version='0.5.0',
     license='MIT',
     description='Log handler to store messages with a database record and optional file storage.',
     keywords=['Django', 'Log', 'App'],


### PR DESCRIPTION
Calling `log.log_data` before logging anything with `save_file` equal to `True` throws an exception because the file doesn't exist.

Handled that in `log_data` by first checking if `filename` is not empty.