### PR TITLE
Add abstract base class to Log model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+db.sqlite3
 test-reports/
 log_storage.egg-info/
 /dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog for `log_storage`.
+
+## UNRELEASED
+
+### Added
+
+- Abstract `Log` model functionality into abstract base model: `BaseLog`.

--- a/log_storage/models.py
+++ b/log_storage/models.py
@@ -1,12 +1,16 @@
 from django.db import models
 
-class Log(models.Model):
+
+class BaseLog(models.Model):
     save_file = models.BooleanField(default=True)
     db_log_data = models.TextField()
     filename = models.CharField(max_length=100)
     created = models.DateTimeField(auto_now_add=True)
     prefix = ''
     suffix = '.log'
+
+    class Meta:
+        abstract = True
 
     def get_filename(self):
         import os, time, random
@@ -78,3 +82,6 @@ class Log(models.Model):
         self._handler = None
         self.save()
 
+
+class Log(BaseLog):
+    pass


### PR DESCRIPTION
This will allow us to use `Log` subclasses without needing to create two tables.

Existing users of `Log` should not notice a difference.