### PR TITLE
Require PRIVATE_STORAGE_ROOT setting to be defined instead of DATA_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for `log_storage`.
 
+
+## v0.7.0
+
+### Changed
+
+Start to require PRIVATE_STORAGE_ROOT setting to be set instead of DATA_ROOT.
+
+
 ## v0.6.0
 
 ### Added

--- a/log_storage/models.py
+++ b/log_storage/models.py
@@ -15,8 +15,8 @@ class BaseLog(models.Model):
     def get_filename(self):
         import os, time, random
         from django.conf import settings
-        root = getattr(settings, 'DATA_ROOT')
-        assert root, "DATA_ROOT setting not set"
+        root = getattr(settings, 'PRIVATE_STORAGE_ROOT')
+        assert root, "PRIVATE_STORAGE_ROOT setting not set"
         path = getattr(settings, 'LOG_DATA_DIR', 'logs')
         if not self.filename:
             self.filename = '_'.join(filter(bool, [self.prefix,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='log_storage',
-    version='0.6.0',
+    version='0.7.0',
     license='MIT',
     description='Log handler to store messages with a database record and optional file storage.',
     keywords=['Django', 'Log', 'App'],

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -73,4 +73,4 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
-DATA_ROOT = os.tmpnam()
+PRIVATE_STORAGE_ROOT = os.tmpnam()


### PR DESCRIPTION
- [x] Require `PRIVATE_STORAGE_ROOT` setting to be defined
- [x] Do not require `DATA_ROOT` setting to be defined anymore.

This is a change to make the app more standard and compatible with other codebases.